### PR TITLE
IS-3 : Provide a full text search & combine the legal cards + (banned cards - (corev2 legal))

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,7 @@ module.exports = function (config) {
   config.set({
     basePath: '',
     frameworks: ['jasmine', '@angular/cli'],
+    files: ['node_modules/jquery/dist/jquery.min.js'],
     plugins: [
       require('karma-jasmine'),
       require('karma-chrome-launcher'),

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "^5.2.0",
+    "@angular/cdk": "5.2.5",
     "@angular/common": "^5.2.0",
     "@angular/compiler": "^5.2.0",
     "@angular/core": "^5.2.0",
@@ -23,6 +24,7 @@
     "@angular/platform-browser-dynamic": "^5.2.0",
     "@angular/router": "^5.2.0",
     "core-js": "^2.4.1",
+    "jquery": "^3.3.1",
     "lodash": "^4.17.10",
     "moment": "^2.22.1",
     "rxjs": "^5.5.6",

--- a/src/netrunner/card.ng.html
+++ b/src/netrunner/card.ng.html
@@ -1,9 +1,12 @@
 <div class="card-cmp">
-  <span *ngIf="card">
-    <span class="col-md-3">{{card.title}}</span>
-    <span class="col-md-2">{{card.faction_code}}</span>
-    <span class="col-md-2">{{card?.pack?.cycle?.name}}</span>
-    <span class="col-md-2">{{card.faction_cost}}</span>
-  </span>
-  <!-- Could add the image but that is a lot of extra size & data -->
+  <div *ngIf="card">
+    <div class="card-details" [class.card-legal]="card?.can_play" [class.card-banned]="!card.can_play">
+      <span class="col-md-3 card-detail">{{card.title}}</span>
+      <span class="col-md-2 card-detail">{{card.faction_code}}</span>
+      <span class="col-md-2 card-detail">{{card?.pack?.cycle?.name}}</span>
+      <span class="col-md-2 card-detail">{{card.faction_cost}}</span>
+      <span class="col-md-1 card-detail">{{card.can_play ? "Legal" : "Banned"}}</span>
+      <!-- Could add the image but that is a lot of extra size & data, probably just on click / timeout loop -->
+    </div>
+  </div>
 </div>

--- a/src/netrunner/card_cmp.spec.ts
+++ b/src/netrunner/card_cmp.spec.ts
@@ -4,17 +4,17 @@ import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {DebugElement} from '@angular/core';
 
 import { RouterTestingModule } from '@angular/router/testing';
-import {NetrunnerCmp} from './netrunner_cmp';
+import {CardCmp} from './card_cmp';
 import {NetrunnerService} from './netrunner_service';
 import {NetrunnerModule} from './netrunner_module';
 import {Card, Cycle, Pack} from './types';
 
 import * as _ from 'lodash';
 declare var $;
-fdescribe('TestingNetrunnerCmp', () => {
-    let fixture: ComponentFixture<NetrunnerCmp>;
+fdescribe('TestingCardCmp', () => {
+    let fixture: ComponentFixture<CardCmp>;
     let service: NetrunnerService;
-    let comp: NetrunnerCmp;
+    let comp: CardCmp;
     let el: HTMLElement;
     let de: DebugElement;
 
@@ -28,18 +28,30 @@ fdescribe('TestingNetrunnerCmp', () => {
         }).compileComponents();
 
         service = TestBed.get(NetrunnerService);
-        fixture = TestBed.createComponent(NetrunnerCmp);
+        fixture = TestBed.createComponent(CardCmp);
         comp = fixture.componentInstance;
 
-        de = fixture.debugElement.query(By.css('.netrunner-cmp'));
+        de = fixture.debugElement.query(By.css('.card-cmp'));
         el = de.nativeElement;
     }));
+
+    function getTotalCards() {
+        return _.get(service.getCards(), 'total');
+    }
 
     it('Should create a netrunner component', () => {
         expect(comp).toBeDefined("We should have the Netrunner comp");
         expect(el).toBeDefined("We should have a top level element");
+
     });
-    
-    // Needs more
+
+    it('Should be able to render a card without exploading and also have a class based on can_play', () => {
+        let card = new Card({title: 'test', faction_code: 'test_faction'});
+        comp.card = card;
+        fixture.detectChanges();
+
+        expect($('.card-details').length).toBe(1, "It should be rendered at this point");
+    });
+
 });
 

--- a/src/netrunner/card_cmp.spec.ts
+++ b/src/netrunner/card_cmp.spec.ts
@@ -39,7 +39,7 @@ fdescribe('TestingCardCmp', () => {
         return _.get(service.getCards(), 'total');
     }
 
-    it('Should create a netrunner component', () => {
+    it('Should create a Card component', () => {
         expect(comp).toBeDefined("We should have the Netrunner comp");
         expect(el).toBeDefined("We should have a top level element");
 
@@ -49,7 +49,6 @@ fdescribe('TestingCardCmp', () => {
         let card = new Card({title: 'test', faction_code: 'test_faction'});
         comp.card = card;
         fixture.detectChanges();
-
         expect($('.card-details').length).toBe(1, "It should be rendered at this point");
     });
 

--- a/src/netrunner/netrunner.ng.html
+++ b/src/netrunner/netrunner.ng.html
@@ -8,6 +8,7 @@
        [ngModel]="searchText"
        (ngModelChange)="searchCards($event)"
       >
+      <span class="error" *ngIf="errMsg">{{errMsg}}</span>
     </span>
 
     <label>

--- a/src/netrunner/netrunner.ng.html
+++ b/src/netrunner/netrunner.ng.html
@@ -9,6 +9,15 @@
        (ngModelChange)="searchCards($event)"
       >
     </span>
+
+    <label>
+      <input name="searchFullText" type="radio" [value]="false"  [(ngModel)]="searchFullText">
+      Title Search
+    </label>
+    <label>
+      <input name="searchFullText" type="radio" [value]="true"  [(ngModel)]="searchFullText">
+      Full Text
+    </label>
   </form>
 
   <div>
@@ -18,14 +27,6 @@
     <h4>Matching Count: {{matchedCards?.length}}</h4>
     <div *ngIf="matchedCards && matchedCards?.length > 0">
       <div *ngFor="let card of matchedCards">
-        <card-cmp [card]="card"></card-cmp>
-      </div>
-    </div>
-  </div>
-  <div>
-    <h4>Banned Count: {{matchedBans?.length}}</h4>
-    <div *ngIf="matchedBans && matchedBans?.length > 0">
-      <div class="row" *ngFor="let card of matchedBans">
         <card-cmp [card]="card"></card-cmp>
       </div>
     </div>

--- a/src/netrunner/netrunner_cmp.spec.ts
+++ b/src/netrunner/netrunner_cmp.spec.ts
@@ -39,7 +39,6 @@ fdescribe('TestingNetrunnerCmp', () => {
         expect(comp).toBeDefined("We should have the Netrunner comp");
         expect(el).toBeDefined("We should have a top level element");
     });
-    
     // Needs more
 });
 

--- a/src/netrunner/netrunner_cmp.ts
+++ b/src/netrunner/netrunner_cmp.ts
@@ -65,7 +65,7 @@ export class NetrunnerCmp implements OnInit {
         let re = null;
         try {
             re = new RegExp(textToFind, 'igm');
-        } catch(err) {
+        } catch (err) {
             this.errMsg = 'Invalid Regex';
         }
         let matchingCards  = _.filter(cards, card => {

--- a/src/netrunner/netrunner_cmp.ts
+++ b/src/netrunner/netrunner_cmp.ts
@@ -67,6 +67,7 @@ export class NetrunnerCmp implements OnInit {
             re = new RegExp(textToFind, 'igm');
         } catch (err) {
             this.errMsg = 'Invalid Regex';
+            console.error("Invalid regex detected in textToFind");
         }
         let matchingCards  = _.filter(cards, card => {
             return card.match(textToFind, re, this.searchFullText);

--- a/src/netrunner/netrunner_service.spec.ts
+++ b/src/netrunner/netrunner_service.spec.ts
@@ -104,7 +104,7 @@ fdescribe('TestingNetrunnerService', () => {
         let bannedCards = service.getBannedCoreCards();
         let legalCards = service.getRevisedCoreCards();
 
-        expect(mergedCards.length < allCards.length).toBe(true, 
+        expect(mergedCards.length < allCards.length).toBe(true,
             "We should have a lot of cards, but definitely some are banned"
         );
 

--- a/src/netrunner/netrunner_service.spec.ts
+++ b/src/netrunner/netrunner_service.spec.ts
@@ -1,0 +1,121 @@
+import {async, fakeAsync, getTestBed, tick, ComponentFixture, TestBed} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {HttpClientTestingModule} from '@angular/common/http/testing';
+import {DebugElement} from '@angular/core';
+
+import { RouterTestingModule } from '@angular/router/testing';
+import {NetrunnerService} from './netrunner_service';
+import {NetrunnerModule} from './netrunner_module';
+import {Card, Cycle, Pack} from './types';
+
+import * as _ from 'lodash';
+declare var $;
+fdescribe('TestingNetrunnerService', () => {
+    let fixture: ComponentFixture<NetrunnerService>;
+    let service: NetrunnerService;
+    let el: HTMLElement;
+    let de: DebugElement;
+
+
+    beforeEach(async( () => {
+        TestBed.configureTestingModule({
+            imports: [RouterTestingModule, NetrunnerModule, HttpClientTestingModule],
+            providers: [
+                NetrunnerService
+            ]
+        }).compileComponents();
+
+        service = TestBed.get(NetrunnerService);
+    }));
+
+    function getTotalCards() {
+        return _.get(service.getCards(), 'total');
+    }
+
+    it('Should create a netrunner service', () => {
+        expect(service).toBeDefined("Should have a service created by the test bed.");
+    });
+
+
+    it('Should be able to build out all the basic object types without error', () => {
+        let cards: Array<Card> = service.getCardInstances();
+        expect(cards).toBeDefined("What the shit, cards didn't even build?");
+        expect(cards.length).toBe(getTotalCards(), "We should have like 1K cards.");
+
+        let cycles: Array<Cycle> = service.getCycleInstances();
+        expect(cycles).toBeDefined("Did you forget a return you monkey");
+        expect(cycles.length).toBe(17, "Should have 17 cycles... what the fuck, how?");
+
+        let packs: Array<Pack> = service.getPackInstances();
+        expect(packs).toBeDefined("Packs not loading, wget / check in the json api?");
+        expect(packs.length).toBe(57, "FML, just take all my money already");
+    });
+
+
+    it('Should be able to determine if a card is legal quickly', () => {
+        let packs: Array<Pack> = service.determineLegalPacks();
+        expect(packs).toBeDefined("We shouldn't be returning nothing");
+        expect(packs.length > 0).toBe(true, "We should have a bunch of packs.");
+
+        _.each(packs, pack => {
+            expect(pack.cycle).toBeDefined("Each pack should have a cycle defined.");
+        });
+    });
+
+
+    it('Should be able to determine the legality of every card', () => {
+        let cards: Array<Card> = service.determineCardLegality();
+        expect(cards).toBeDefined("Fucking list of all the damn cards.");
+        expect(cards.length).toBe(getTotalCards(), "All the card objects are here, we have not filtered down yet.");
+        _.each(cards, card => {
+            expect(card.pack).toBeDefined("We should have assigned a pack to each and every card.");
+        });
+
+        let revisedCore: Array<Card> = service.getRevisedCoreCards();
+        expect(revisedCore).toBeDefined("We should have a bunch of revised cards");
+        expect(revisedCore.length < cards.length).toBe(true, "We should have many fewer revised core cards.");
+        expect(revisedCore.length > 800).toBe(true, "There should be a lot of them.");
+    });
+
+    it("Should be able to determine specific known cards as a base test", () => {
+        let bannedNoise: Card = new Card({pack_code: 'core', title: "Noise: Hacker Extraordinaire"});
+        let bannedSanSan: Card = new Card({pack_code: 'ta', title: 'Vamp'});
+        let legalBeale: Card = new Card({pack_code: 'core2', title: 'Project Beale'});
+
+        let nopes: Array<Card> = service.determineCardLegality([bannedNoise, bannedSanSan, legalBeale]);
+        expect(nopes.length).toBe(3, "We should get ALL cards back, just determine legal play");
+        expect(bannedNoise.can_play).toBe(false, "No more Noise, This should not be legal");
+        expect(bannedSanSan.can_play).toBe(false, "SanSan nope, This should not be legal");
+        expect(legalBeale.can_play).toBe(true, "This made it into core2");
+
+
+        let allCards = service.determineCardLegality();
+        let bannedCards = service.getBannedCoreCards();
+        let legalCards = service.getRevisedCoreCards();
+
+        expect(allCards.length > bannedCards.length).toBe(true, "The total should be more than the bans.");
+        expect(allCards.length > legalCards.length).toBe(true, "Same for the count of legal to all cards.");
+        expect(legalCards.length + bannedCards.length).toBe(allCards.length, "We should still add up to the total");
+    });
+
+    it('Should be able to get a distinct list of all the cards merging the legal core2 vs core', () => {
+        let mergedCards = service.getDistinctNamedCards();
+        let allCards = service.determineCardLegality();
+        let bannedCards = service.getBannedCoreCards();
+        let legalCards = service.getRevisedCoreCards();
+
+        expect(mergedCards.length < allCards.length).toBe(true, 
+            "We should have a lot of cards, but definitely some are banned"
+        );
+
+        let groups = _.groupBy(mergedCards, 'can_play');
+        let mergedLegal = groups[true];
+        let mergedBanned = groups[false];
+        expect(mergedLegal.length).toBe(legalCards.length, "Should have all the legal cards in the merged list");
+        expect(mergedBanned.length > 0 && mergedBanned.length < bannedCards.length).toBe(true,
+            "Should have many bans, but not all"
+        );
+    });
+
+});
+

--- a/src/netrunner/netrunner_service.ts
+++ b/src/netrunner/netrunner_service.ts
@@ -15,6 +15,25 @@ export class NetrunnerService {
 
     }
 
+    public getDistinctNamedCards() {
+        let allCards: Array<Card> = this.determineCardLegality();
+        let legalCards = this.getRevisedCoreCards(allCards);
+        let bannedCards = this.getBannedCoreCards(allCards);
+ 
+        let distinctLookup = _.groupBy(legalCards, 'title');
+        _.each(bannedCards, bc => {
+            if (!distinctLookup[bc.title]) {
+                distinctLookup[bc.title] = bc;
+            }   
+        });
+        let combinedDistinct = [];
+        _.each(distinctLookup, (card, key) => {
+            combinedDistinct.push(_.isArray(card) ? card[0] : card);
+        });
+		return combinedDistinct;
+    }
+
+
     public determineLegalPacks(packs: Array<Pack> = null, cycles: Array<Cycle> = null) {
         cycles = cycles || this.getCycleInstances();
         packs = packs || this.getPackInstances();
@@ -44,6 +63,7 @@ export class NetrunnerService {
             } else {
                 console.error("What the fuck, no pack found for this card?", card);
             }
+            card.fullText = card.buildFullText(); // One time cost, build out the search text
         });
         return cards;
     }

--- a/src/netrunner/netrunner_service.ts
+++ b/src/netrunner/netrunner_service.ts
@@ -19,18 +19,18 @@ export class NetrunnerService {
         let allCards: Array<Card> = this.determineCardLegality();
         let legalCards = this.getRevisedCoreCards(allCards);
         let bannedCards = this.getBannedCoreCards(allCards);
- 
+
         let distinctLookup = _.groupBy(legalCards, 'title');
         _.each(bannedCards, bc => {
             if (!distinctLookup[bc.title]) {
                 distinctLookup[bc.title] = bc;
-            }   
+            }
         });
         let combinedDistinct = [];
         _.each(distinctLookup, (card, key) => {
             combinedDistinct.push(_.isArray(card) ? card[0] : card);
         });
-		return combinedDistinct;
+        return combinedDistinct;
     }
 
 

--- a/src/netrunner/types.ts
+++ b/src/netrunner/types.ts
@@ -9,8 +9,10 @@ export class Cycle {
     public size: number; // Number of packs
     public rotated: boolean; // Is it out of rotation
 
+    public raw: any;
     constructor(raw) {
         Object.assign(this, raw);
+        this.raw = raw || {};
     }
 }
 
@@ -28,8 +30,10 @@ export class Pack {
     // This is calculated from the cycle it belongs to, you have to lookup cycle_code -> cycle.code
     public cycle: Cycle;
 
+    public raw: any;
     constructor(raw) {
         Object.assign(this, raw);
+        this.raw = raw || {};
     }
 }
 
@@ -53,6 +57,7 @@ export class Card {
     public uniqueness: boolean; // wtf is this?
 
     public text: string;
+    public fullText: string;
     // "Draft format only. If you have more [jinteki] cards rezzed than any other faction, when
     // your turn begins, you may swap 2 pieces of installed ice."
     public pack: Pack;
@@ -61,9 +66,34 @@ export class Card {
     // reference against CORE
     public can_play: boolean = false;
 
+    public raw: any;
     constructor(raw) {
         Object.assign(this, raw);
-
         this.title_lower = this.title ? this.title.toLowerCase() : '';
+        this.raw = raw || {};
+    }
+
+    public buildFullText() {
+        let text: string = _.compact(_.values(this.raw)).join(' ') + ' ';
+        if (this.pack) {
+            text += _.compact(_.values(this.pack.raw || {})).join(' ') + ' ';
+            if (this.pack.cycle) {
+                text += _.compact(_.values(this.pack.cycle.raw)).join(' ') + ' ';
+            }
+        }
+        return text;
+    }
+
+    public match(textString: string, re: RegExp, fullTextSearch = false) {
+        if (re) {
+            if (this.fullText && fullTextSearch) {
+                return re.test(this.fullText);
+            } else {
+                return re.test(this.title);
+            }
+        } else if (textString) {
+            return this.title.match(textString);
+        }
+        return false;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,6 +33,12 @@
   dependencies:
     tslib "^1.7.1"
 
+"@angular/cdk@5.2.5":
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-5.2.5.tgz#cae2b12e1990a692dd267a73fdb1d49db37f9604"
+  dependencies:
+    tslib "^1.7.1"
+
 "@angular/cli@~1.7.0":
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-1.7.4.tgz#b6c31b5fc6f8ea07e55b1b01a26422f5358a4ea6"
@@ -3406,6 +3412,10 @@ jasmine@^2.5.3:
 jasminewd2@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jasminewd2/-/jasminewd2-2.2.0.tgz#e37cf0b17f199cce23bea71b2039395246b4ec4e"
+
+jquery@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
 
 js-base64@^2.1.8:
   version "2.4.3"


### PR DESCRIPTION
- To get the full list of cards without dupes it grabs all the legal cards, then adds the banned cards by title that are _not_ already in the legal list.
- Adds a few tests around that
- simplify the search logic
- add a radio toggle to determine full text vs title search
- Build out the full text search from the json values.